### PR TITLE
Double container memory limit and reservation

### DIFF
--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -19,12 +19,12 @@ variable "cpu_limit" {
 
 variable "mem_limit" {
   type    = number
-  default = 64
+  default = 128
 }
 
 variable "mem_reservation" {
   type    = number
-  default = 32
+  default = 96
 }
 
 variable "container_restart_policy_enabled" {


### PR DESCRIPTION
Increase mem_limit from 64 to 128 and mem_reservation from 32 to 96 to give the container more headroom under load.