### PR TITLE
Tag the build Flow with its target environment

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,6 +58,8 @@ jobs:
         uses: cyber-dojo/kosli-begin-trail@main
         with:
           flow_description: "Exercises choices"
+          flow_tags: |
+            env=aws-beta
 
 
   pull-request:


### PR DESCRIPTION
  The per-environment trail-compliance policies scope on flow.tags.env, and the
  build Flow deploys to aws-beta. Pass flow_tags to kosli-begin-trail so the Flow
  is tagged env=aws-beta, letting the aws-beta policy require it and the aws-prod
  policy waive it.

  Requires the flow_tags input added to kosli-begin-trail@main.

  Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>