### PR TITLE
Declare sbom and provenance facts+decision attestations in the trail …

### DIFF
--- a/.kosli.yml
+++ b/.kosli.yml
@@ -7,7 +7,14 @@ trail:
   artifacts:
     - name: exercises-start-points
       attestations:
-        - name: provenance
+        - name: provenance-facts
+          type: custom:provenance-facts
+        - name: provenance-decision
+          type: decision
+
+        - name: sbom-facts
+          type: custom:sbom-facts
+        - name: sbom-decision
           type: decision
 
         - name: snyk-container-scan


### PR DESCRIPTION
Declare sbom and provenance facts+decision attestations in the trail template

The build now attests dependency (SBOM) and SLSA-provenance evidence via
      the shared secure-start-point-build workflow - a custom facts attestation
      plus a decision per control. Declare them in the Kosli trail template so
      the sdlc-gate expects and matches what the workflow produces:
        provenance-facts (custom) + provenance-decision  -- SDLC-CTRL-0002
        sbom-facts (custom) + sbom-decision              -- SDLC-CTRL-0004
      replacing the single bare `provenance` decision entry.