### PR TITLE
Fail fast when the image lookup cannot obtain credentials

### DIFF
--- a/.github/workflows/detect-drift-env.yml
+++ b/.github/workflows/detect-drift-env.yml
@@ -26,18 +26,26 @@ on:
 jobs:
   image:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       id-token: write
       contents: read
     outputs:
       image: ${{ steps.read.outputs.image }}
     steps:
+      # The credential bounds below are the standard for any Kosli workflow using
+      # configure-aws-credentials; see the Timeouts section of kosli-dev/tf's README.
+      # An unreachable STS endpoint fails in under a minute instead of holding the
+      # runner for over an hour on retries that were never going to succeed.
       - name: Configure AWS credentials
+        timeout-minutes: 2
         uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           role-to-assume: arn:aws:iam::${{ inputs.aws_account_id }}:role/gh_actions_services
           aws-region: eu-central-1
           role-session-name: ${{ github.event.repository.name }}
+          action-timeout-s: 45
+          retry-max-attempts: 3
       - name: Read deployed image
         id: read
         run: |


### PR DESCRIPTION
  The scheduled drift run's `Configure AWS credentials` step spent 1h23m
  failing with `connect ETIMEDOUT` against the STS endpoint. No socket was
  ever opened, so no attempt was going to succeed, but the action's twelve
  default retries each sat on an OS-level TCP connect timeout and the
  runner was held for the whole time.

  The shared kosli-dev/tf drift workflow already bounds its own credential
  steps this way. This `image` job is local to this repository, so that
  change did not reach it and it kept the unbounded behaviour.

    action-timeout-s: 45     bounds the action as a whole, retries included
    retry-max-attempts: 3    twelve attempts only help if each one is fast
    timeout-minutes: 2       backstop, independent of the action's behaviour

  The job also gets an explicit `timeout-minutes: 5` rather than inheriting
  GitHub's 360-minute default, which an 83-minute hang would never trip. It
  authenticates and reads one ECS task definition, so 5 is ample.

  The values follow the standard recorded in the Timeouts section of
  kosli-dev/tf's README.